### PR TITLE
Add pause controls for largest torrents

### DIFF
--- a/2026/transmiscripts/app.py
+++ b/2026/transmiscripts/app.py
@@ -12,7 +12,7 @@ import pause_by_list as pl
 import transmission_high_ratio as hr
 import transmission_largest as lg
 import transmission_notfound as nf
-from transmission_client import env_credentials, format_bytes
+from transmission_client import TransmissionClient, env_credentials, format_bytes
 
 app = Flask(__name__)
 
@@ -132,6 +132,25 @@ def largest_scan():
             "count": len(torrents),
             "total_size_str": format_bytes(total),
         })
+    except (urllib.error.URLError, OSError) as e:
+        return _conn_error(e)
+    except Exception as e:
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
+@app.route("/api/largest/pause", methods=["POST"])
+def largest_pause():
+    data = request.get_json(force=True)
+    torrent_id = data.get("id")
+    try:
+        torrent_id = int(torrent_id)
+    except (TypeError, ValueError):
+        return jsonify({"success": False, "error": "id is required"}), 400
+
+    try:
+        client = TransmissionClient(**_conn(data))
+        client.pause_torrents([torrent_id])
+        return jsonify({"success": True, "paused": 1, "id": torrent_id})
     except (urllib.error.URLError, OSError) as e:
         return _conn_error(e)
     except Exception as e:

--- a/2026/transmiscripts/templates/index.html
+++ b/2026/transmiscripts/templates/index.html
@@ -69,6 +69,7 @@
   .btn-scan:hover:not(:disabled) { background: var(--accent-h); }
   .btn-pause { background: var(--danger); color: #fff; }
   .btn-pause:hover:not(:disabled) { background: var(--danger-h); }
+  .btn-small { padding: 5px 10px; font-size: 12px; }
 
   /* Status / alerts */
   .status-msg { font-size: 13px; padding: 8px 12px; border-radius: 5px; display: none; }
@@ -451,11 +452,27 @@ function buildLargestTable(torrents) {
       <td style="text-align:right;font-weight:600;color:var(--accent)">${t.total_size_str}</td>
       <td style="text-align:right">${t.upload_ratio.toFixed(2)}</td>
       <td>${t.uploaded_ever_str}</td>
+      <td><button class="btn-pause btn-small" data-name="${esc(t.name)}" onclick="largestPause(${t.id}, this.dataset.name)">Pause</button></td>
     </tr>`).join('');
   return `<table>
-    <thead><tr><th>#</th><th>Name</th><th>Size</th><th>Ratio</th><th>Uploaded</th></tr></thead>
+    <thead><tr><th>#</th><th>Name</th><th>Size</th><th>Ratio</th><th>Uploaded</th><th>Action</th></tr></thead>
     <tbody>${rows}</tbody>
   </table>`;
+}
+
+async function largestPause(id, name) {
+  if (!validateConn()) return;
+  if (!confirm(`Pause this torrent?\n\n${name}`)) return;
+
+  setStatus('lg-status', 'info', 'Sending pause command…');
+  try {
+    const data = await api('/api/largest/pause', { ...conn(), id });
+    if (!data.success) { setStatus('lg-status', 'err', data.error); return; }
+    setStatus('lg-status', 'ok', 'Paused 1 torrent.');
+    largestScan(); // refresh
+  } catch (e) {
+    setStatus('lg-status', 'err', `Request failed: ${e.message}`);
+  }
 }
 
 // ── Not in Transmission ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add a per-row Pause button to the Largest Seeding table
- Add a Flask endpoint to pause an individual largest torrent by ID
- Refresh the largest torrent list after pausing

## Testing
- python3 -m py_compile 2026/transmiscripts/app.py 2026/transmiscripts/transmission_client.py 2026/transmiscripts/transmission_largest.py