### PR TITLE
Fix not-found path mapping and deletion

### DIFF
--- a/2026/transmiscripts/app.py
+++ b/2026/transmiscripts/app.py
@@ -40,6 +40,13 @@ def index():
     return render_template("index.html")
 
 
+@app.route("/api/config", methods=["GET"])
+def config():
+    return jsonify({
+        "notfound_path": nf.DEFAULT_PATH,
+    })
+
+
 # ---------------------------------------------------------------------------
 # Ratio endpoints
 # ---------------------------------------------------------------------------
@@ -178,6 +185,28 @@ def notfound_scan():
             "total_size_str": format_bytes(total),
         })
     except FileNotFoundError as e:
+        return jsonify({"success": False, "error": str(e)}), 400
+    except (urllib.error.URLError, OSError) as e:
+        return _conn_error(e)
+    except Exception as e:
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
+@app.route("/api/notfound/delete", methods=["POST"])
+def notfound_delete():
+    data = request.get_json(force=True)
+    name = data.get("name", "")
+    if not name:
+        return jsonify({"success": False, "error": "name is required"}), 400
+
+    try:
+        deleted = nf.delete_notfound_entry(
+            **_conn(data),
+            path=data.get("path", nf.DEFAULT_PATH),
+            name=name,
+        )
+        return jsonify({"success": True, "deleted": deleted})
+    except (FileNotFoundError, ValueError) as e:
         return jsonify({"success": False, "error": str(e)}), 400
     except (urllib.error.URLError, OSError) as e:
         return _conn_error(e)

--- a/2026/transmiscripts/docker-compose.yml
+++ b/2026/transmiscripts/docker-compose.yml
@@ -4,8 +4,12 @@ services:
   app:
     build: .
     ports:
-      - "8073:8073"
+      - "${APP_PORT:-8073}:8073"
     environment:
       - TRANSMIUSER=${TRANSMIUSER:-}
       - TRANSMIPASS=${TRANSMIPASS:-}
+      - NOTFOUND_TRANSMISSION_PATH=${NOTFOUND_TRANSMISSION_PATH:-/home/giovas/dostb/transmi/complete}
+      - NOTFOUND_LOCAL_PATH=${NOTFOUND_CONTAINER_PATH:-/home/giovas/dostb/transmi/complete}
+    volumes:
+      - ${NOTFOUND_HOST_PATH:-/home/giovas/dostb/transmi/complete}:${NOTFOUND_CONTAINER_PATH:-/home/giovas/dostb/transmi/complete}
     restart: unless-stopped

--- a/2026/transmiscripts/readme.txt
+++ b/2026/transmiscripts/readme.txt
@@ -65,20 +65,42 @@ Web UI / API
     POST /api/list/pause        { glob_text, threshold }
     POST /api/largest/scan      { top }
     POST /api/notfound/scan     { path, top }
+    POST /api/notfound/delete   { path, name }
 
 Docker
 ------
   Build and run with Docker Compose (recommended):
     docker compose up -d
 
+  If host port 8073 is already in use:
+    APP_PORT=8074 docker compose up -d
+
   The stack is named "transmiscripts"; containers appear as transmiscripts-app-1.
   TRANSMIUSER and TRANSMIPASS are forwarded from the host shell if set.
+
+  The Not in Transmission panel needs the app container to see the same
+  download files that Transmission reports over RPC. By default compose mounts:
+
+    /home/giovas/dostb/transmi/complete
+
+  into the same path inside the app container. Override these when your host
+  path, app-container path, or Transmission-reported path differ:
+
+    NOTFOUND_HOST_PATH=/host/downloads
+    NOTFOUND_CONTAINER_PATH=/downloads
+    NOTFOUND_TRANSMISSION_PATH=/downloads
+
+  The web UI scans the Transmission path and maps it to NOTFOUND_CONTAINER_PATH
+  before reading or deleting files.
 
   Or build and run manually:
     docker build -t transmiscripts .
     docker run -p 8073:8073 \
       -e TRANSMIUSER="your_username" \
       -e TRANSMIPASS="your_secret_password" \
+      -e NOTFOUND_TRANSMISSION_PATH="/downloads" \
+      -e NOTFOUND_LOCAL_PATH="/downloads" \
+      -v /host/downloads:/downloads \
       transmiscripts
 
   The web UI will be available at http://localhost:8073

--- a/2026/transmiscripts/templates/index.html
+++ b/2026/transmiscripts/templates/index.html
@@ -264,6 +264,20 @@ async function api(endpoint, body) {
   return resp.json();
 }
 
+async function loadConfig() {
+  try {
+    const resp = await fetch('/api/config');
+    const data = await resp.json();
+    if (data.notfound_path) {
+      document.getElementById('nf-path').value = data.notfound_path;
+    }
+  } catch (e) {
+    // Defaults in the page are enough if config cannot be loaded.
+  }
+}
+
+loadConfig();
+
 // ── Ratio ──────────────────────────────────────────────────────────────────
 
 async function ratioScan() {
@@ -513,11 +527,29 @@ function buildNotfoundTable(entries) {
       <td style="max-width:300px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;" title="${esc(e.name)}">${esc(e.name)}</td>
       <td style="color:var(--text-muted)">${esc(e.modified_str)}</td>
       <td style="text-align:right">${e.size_str}</td>
+      <td><button class="btn-pause btn-small" data-name="${esc(e.name)}" onclick="notfoundDelete(this.dataset.name)">Delete</button></td>
     </tr>`).join('');
   return `<table>
-    <thead><tr><th>#</th><th>Name</th><th>Modified</th><th>Size</th></tr></thead>
+    <thead><tr><th>#</th><th>Name</th><th>Modified</th><th>Size</th><th>Action</th></tr></thead>
     <tbody>${rows}</tbody>
   </table>`;
+}
+
+async function notfoundDelete(name) {
+  if (!validateConn()) return;
+  const path = document.getElementById('nf-path').value.trim();
+  if (!path) { setStatus('nf-status', 'err', 'Path is required.'); return; }
+  if (!confirm(`Delete this untracked entry from disk?\n\n${name}`)) return;
+
+  setStatus('nf-status', 'info', 'Deleting…');
+  try {
+    const data = await api('/api/notfound/delete', { ...conn(), path, name });
+    if (!data.success) { setStatus('nf-status', 'err', data.error); return; }
+    setStatus('nf-status', 'ok', `Deleted ${data.deleted.kind}: ${data.deleted.name}`);
+    notfoundScan();
+  } catch (e) {
+    setStatus('nf-status', 'err', `Request failed: ${e.message}`);
+  }
 }
 </script>
 </body>

--- a/2026/transmiscripts/transmission_notfound.py
+++ b/2026/transmiscripts/transmission_notfound.py
@@ -13,13 +13,15 @@ Usage:
 
 import argparse
 import os
+import shutil
 import sys
 import urllib.error
 from datetime import datetime
 
 from transmission_client import TransmissionClient, format_bytes, env_credentials
 
-DEFAULT_PATH = "/home/giovas/dostb/transmi/complete"
+DEFAULT_PATH = os.environ.get("NOTFOUND_TRANSMISSION_PATH", "/home/giovas/dostb/transmi/complete")
+DEFAULT_LOCAL_PATH = os.environ.get("NOTFOUND_LOCAL_PATH", DEFAULT_PATH)
 
 TORRENT_FIELDS = ["id", "name", "downloadDir", "totalSize", "status"]
 
@@ -27,6 +29,41 @@ TORRENT_FIELDS = ["id", "name", "downloadDir", "totalSize", "status"]
 # ---------------------------------------------------------------------------
 # Importable API (used by Flask app)
 # ---------------------------------------------------------------------------
+
+def _is_within(path: str, base: str) -> bool:
+    try:
+        return os.path.commonpath([path, base]) == base
+    except ValueError:
+        return False
+
+
+def resolve_scan_paths(path: str) -> tuple[str, str]:
+    """Return (transmission_path, local_path) for a requested download path."""
+    requested = os.path.normpath(path)
+    transmission_base = os.path.normpath(DEFAULT_PATH)
+    local_base = os.path.normpath(DEFAULT_LOCAL_PATH)
+
+    if requested == local_base or _is_within(requested, local_base):
+        rel = os.path.relpath(requested, local_base)
+        transmission_path = transmission_base if rel == "." else os.path.normpath(os.path.join(transmission_base, rel))
+        return transmission_path, requested
+
+    if requested == transmission_base or _is_within(requested, transmission_base):
+        rel = os.path.relpath(requested, transmission_base)
+        local_path = local_base if rel == "." else os.path.normpath(os.path.join(local_base, rel))
+        return requested, local_path
+
+    return requested, requested
+
+
+def _tracked_names(torrents: list, transmission_path: str) -> set:
+    norm_path = os.path.normpath(transmission_path)
+    return {
+        t["name"]
+        for t in torrents
+        if os.path.normpath(t["downloadDir"]) == norm_path
+    }
+
 
 def scan_notfound(
     host: str = "localhost",
@@ -45,20 +82,16 @@ def scan_notfound(
     client = TransmissionClient(host, port, user, password)
     torrents = client.get_torrents(TORRENT_FIELDS)
 
-    # Build a set of names tracked by Transmission in the target directory.
-    # Normalise both sides so trailing slashes don't cause mismatches.
-    norm_path = os.path.normpath(path)
-    tracked = {
-        t["name"]
-        for t in torrents
-        if os.path.normpath(t["downloadDir"]) == norm_path
-    }
+    transmission_path, local_path = resolve_scan_paths(path)
+    tracked = _tracked_names(torrents, transmission_path)
 
-    if not os.path.isdir(norm_path):
-        raise FileNotFoundError(f"Directory not found: {norm_path}")
+    if not os.path.isdir(local_path):
+        if transmission_path != local_path:
+            raise FileNotFoundError(f"Directory not found: {local_path} (mapped from {transmission_path})")
+        raise FileNotFoundError(f"Directory not found: {local_path}")
 
     orphans = []
-    for entry in os.scandir(norm_path):
+    for entry in os.scandir(local_path):
         if entry.name in tracked:
             continue
         stat = entry.stat(follow_symlinks=False)
@@ -73,6 +106,41 @@ def scan_notfound(
 
     orphans.sort(key=lambda e: e["modified"])
     return orphans[:top]
+
+
+def delete_notfound_entry(
+    host: str = "localhost",
+    port: int = 9091,
+    user: str = "",
+    password: str = "",
+    path: str = DEFAULT_PATH,
+    name: str = "",
+) -> dict:
+    """Delete one untracked filesystem entry by name from *path*."""
+    if not name or os.path.basename(name) != name:
+        raise ValueError("name must be a single file or folder name")
+
+    client = TransmissionClient(host, port, user, password)
+    torrents = client.get_torrents(TORRENT_FIELDS)
+    transmission_path, local_path = resolve_scan_paths(path)
+
+    if name in _tracked_names(torrents, transmission_path):
+        raise ValueError("Refusing to delete an entry that is tracked by Transmission")
+
+    target = os.path.normpath(os.path.join(local_path, name))
+    if not _is_within(target, os.path.normpath(local_path)):
+        raise ValueError("Refusing to delete outside the scanned directory")
+    if not os.path.lexists(target):
+        raise FileNotFoundError(f"Entry not found: {target}")
+
+    if os.path.isdir(target) and not os.path.islink(target):
+        shutil.rmtree(target)
+        kind = "directory"
+    else:
+        os.unlink(target)
+        kind = "file"
+
+    return {"name": name, "full_path": target, "kind": kind}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- map Transmission download paths to the app container filesystem for not-found scans
- add per-entry deletion for untracked files and folders with backend safety checks
- document Docker mount and port configuration

## Tests
- python3 -m py_compile app.py transmission_notfound.py transmission_client.py pause_by_list.py transmission_high_ratio.py transmission_largest.py
- docker compose config