### PR TITLE
Fix Django vulnerabilities found by trivy fs scan in /djangoCourse

### DIFF
--- a/djangoCourse/requirements.txt
+++ b/djangoCourse/requirements.txt
@@ -1,6 +1,6 @@
 #astroid==2.2.5
 certifi==2026.7.22
-Django==4.2.30
+Django==5.2.16
 isort==4.3.21
 lazy-object-proxy==1.4.1
 mccabe==0.6.1


### PR DESCRIPTION
## Summary
- \`trivy fs --scanners vuln,secret,misconfig .\` flagged 6 CVEs against Django 4.2.30 in `djangoCourse/requirements.txt` (the FlaskJerigonza copy was already patched in a prior PR).
- Bumps Django from 4.2.30 to 5.2.16, the fixed version for all reported CVEs (CVE-2026-53877, CVE-2026-53878, CVE-2026-48587, CVE-2026-48588, CVE-2026-6873, CVE-2026-8404).

## Test plan
- [x] `trivy fs --scanners vuln djangoCourse` now reports 0 vulnerabilities
- [x] `python manage.py check` passes for both `wordcount` and `portfolio` projects under Django 5.2.16 (only a pre-existing, unrelated `W042` auto-pk warning remains)

🤖 Generated with [Claude Code](https://claude.com/claude-code)